### PR TITLE
Add initialisation of queues to .jenkins

### DIFF
--- a/src/.jenkins/initialise_queues.py
+++ b/src/.jenkins/initialise_queues.py
@@ -1,0 +1,52 @@
+import sys
+import pika
+
+from gobworkflow.config import MESSAGE_BROKER, QUEUES
+
+
+def create_durable_message_queue(exchange, channel, name, route):
+    """Creates a persistent message queue on the RabbitMQ message broker
+
+    :param exchange: RabbitMQ exchande
+    :param channel: RabbitMQ channel
+    :param name: The name for queue to create
+    :param route: The route(s) on the queue
+    :return: RabbitMQ exchange
+    """
+
+    print(f"Create durable message queue {name} {route}")
+
+    channel.queue_declare(
+        queue=name,
+        durable=True
+    )
+
+    channel.queue_bind(
+        queue=name,
+        exchange=exchange,
+        routing_key=route
+    )
+
+
+if __name__ == "__main__":
+    try:
+        with pika.BlockingConnection(pika.ConnectionParameters(MESSAGE_BROKER)) as connection:
+            channel = connection.channel()
+
+            for queue in QUEUES:
+                channel.exchange_declare(
+                    exchange=queue['exchange'],
+                    exchange_type="topic",
+                    durable=True)
+
+                create_durable_message_queue(
+                    exchange=queue['exchange'],
+                    channel=channel,
+                    name=queue['name'],
+                    route=queue['key'])
+
+            print("Succesfully created RabbitMQ message queues at 'localhost'")
+
+    except Exception as e:
+        print("Error: Failed to connect to RabbitMQ at 'localhost', {str(e)}")
+        sys.exit(1)

--- a/src/gobworkflow/__main__.py
+++ b/src/gobworkflow/__main__.py
@@ -4,6 +4,7 @@ from gobworkflow.config import MESSAGE_BROKER, QUEUES, WORKFLOW_QUEUE, LOG_QUEUE
 from gobworkflow.message_broker.async_message_broker import AsyncConnection
 
 
+# todo this has been made more generic in GOB-Upload, refactor here, move it to package
 def on_message(connection, queue, key, msg):
     """Called on every message receipt
 

--- a/src/gobworkflow/config.py
+++ b/src/gobworkflow/config.py
@@ -2,18 +2,23 @@ import os
 
 MESSAGE_BROKER = os.environ["MESSAGE_BROKER_ADDRESS"]
 
-WORKFLOW_QUEUE = "gob.workflow.proposal"
-LOG_QUEUE = "gob.log.all"
+WORKFLOW_QUEUE = "gob.workflow"
+LOG_QUEUE = "gob.log"
 
 QUEUES = [
     {
         "exchange": "gob.workflow",
-        "name": WORKFLOW_QUEUE,
+        "name": WORKFLOW_QUEUE+'.proposal',
         "key": "*.proposal"
     },
     {
+        "exchange": "gob.workflow",
+        "name": WORKFLOW_QUEUE+'.request',
+        "key": "*.request"
+    },
+    {
         "exchange": "gob.log",
-        "name": LOG_QUEUE,
+        "name": LOG_QUEUE+'.all',
         "key": "#"
     }
 ]


### PR DESCRIPTION
The workflow service is in charge of the initialisation of queues. A
local script was present, but not one the allow initialisation on
release and deploy.

That is now added.

Creation of queues is idempotent, it will not destroy existing queues.