### PR TITLE
Fix gobcore requirement

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,7 +2,7 @@ atomicwrites==1.1.5
 attrs==18.1.0
 coverage==4.5.1
 flake8==3.5.0
--e git+https://github.com/Amsterdam/GOB-Core@39f77c2d868c200aeb1859d6df037ab8ba348933#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core@v0.2.1#egg=gobcore
 mccabe==0.6.1
 mock==2.0.0
 more-itertools==4.2.0


### PR DESCRIPTION
Add the current version of gobcore to the requirements to fix an issue with referring to a non-existing commit.