### PR TITLE
Move infra components to GOB-Infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,119 +2,60 @@
 
 GOB Workflow is the central component within GOB.
 
-The following functions are performed:
-
-## Routing
-
-GOB Workflow will subscribe on all relevant queues and is responsable for routing received messages according to the defined workflows.
-
-In its first version the workflow will:
-- subscribe to log messages and print the messages on stdout
+GOB Workflow subscribes to all relevant queues
+and is responsable for routing received messages according to the defined workflows:
+- subscribe to log messages and store the messages in the management database
 - subscribe to workflow messages, inspect the message and route it further
 
-## Monitoring
+# Docker
 
-All log messages will eventually be stored in a database and exposed over a REST API.
-A frontend application can use this API to display the components, status and condition of the GOB components.
+## Requirements
 
-GOB components might publish heartbeats to be able to show if components are active or not.
+* docker-compose >= 1.17
+* docker ce >= 18.03
 
-## Control
+## Run
 
-Workflow message inspection might give rise to asking the user to confirm or reject the message.
+```bash
+docker-compose up &
+```
 
-An example might be that an update is received to delete 80% of all database rows of a specific table.
-Instead of routing this message automatically to the next step and deleting the 80% records the user might be asked to confirm this.
-The message will then be routed further or rejected.
+# Local
 
-# Requirements
+## Requirements
 
-    * docker-compose >= 1.17
-    * docker ce >= 18.03
-    * python >= 3.6
+* python >= 3.6
     
-# Local Installation
+## Initialisation
 
 Create a virtual environment:
 
-    python3 -m venv venv
-    source venv/bin/activate
-    pip install -r src/requirements.txt
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r src/requirements.txt
+```
     
 Or activate the previously created virtual environment
 
-    source venv/bin/activate
+```bash
+source venv/bin/activate
+```
     
-## RabbitMQ
+## Run
 
-For the benefits of local development an instance of RabbitMQ can be spun up,
-it will run on the gob-network, which needs to be created manually,
-if it doesn't exist yet:
-
-```bash
-docker network create gob-network
-```
-
-Then start the dockerized instance of RabbitMQ:
-
-```bash
-docker-compose up rabbitmq &
-```
-
-This starts the RabbitMQ message broker with hostname "rabbitmq" on the gob-network.
-Locally the RabbitMQ message broker can be accessed by "localhost".
-
-RabbitMQ operates on port 5672 (used by Advanced Message Queuing Protocol (AMQP) 0-9-1 and 1.0 clients)
-
-The [RabbitMQ management interface](https://www.rabbitmq.com/management.html) is available at port 15672:
-
-    http://localhost:15672
-
-If it is the first run of RabbitMQ, the GOB message queues need to be initialised 
-_using the current virtual environment:_
+Start the client:
 
 ```bash
 cd src
-python initialise_queues.py
+python -m gobworkflow
 ```
-
-## Management database
-
-Log messages are stored in a management database.
-In order to start the Workflow the management database has to be running:
-
-```
-docker-compose up management_database &
-```
-
-## Management database
-
-Log messages are stored in a management database.
-In order to start the Workflow the management database has to be running:
-
-```
-docker-compose up management_database &
-```
-
-# Running locally
-
-If the message broker is not running on localhost,
-expose the IP address of the message broker in the environment:
-
-```bash
-export MESSAGE_BROKER_ADDRESS=<address>
-```
-
-Start the client, _using the virtual environment_:
-
-    (venv) $ cd src
-    (venv) $ python -m gobworkflow
-    
+   
 ## Tests
 
-To run the tests, _using the virtual environment_:
+Run the tests:
 
-    (venv) $ cd src
-    (venv) $ sh test.sh
-
-Currently there are no tests for this project.
+```bash
+cd src
+sh test.sh
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 
 services:
-
   workflow_service:
     build: src
     container_name: workflow_service
@@ -13,29 +12,9 @@ services:
     volumes:
       - gob-volume:/app/shared
 
-  rabbitmq:
-    image: "rabbitmq:3-management"
-    container_name: rabbitmq
-    ports:
-    - "15672:15672"
-    - "5672:5672"
-
-  management_database:
-    image: amsterdam/postgres
-    ports:
-    - "5407:5432"
-    container_name: management_database
-    environment:
-      POSTGRES_PASSWORD: insecure
-      POSTGRES_DB: gob_management
-      POSTGRES_USER: gob
-    volumes:
-    - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
-
 volumes:
   gob-volume:
     external: true
-
 
 networks:
   default:


### PR DESCRIPTION
The RabbitMQ and Management database creation is moved to
the GOB-Infra repository

The documentation has been updated accordingly and simplified