### PR TITLE
Auto reconnect wrapper

### DIFF
--- a/src/gobworkflow/storage/auto_reconnect_wrapper.py
+++ b/src/gobworkflow/storage/auto_reconnect_wrapper.py
@@ -1,0 +1,109 @@
+"""Auto reconnect wrapper
+
+A wrapper that tracks execution failures that are caused by connection problems.
+It does so by catching exceptions on command execution
+
+If a connection problem is detected the connection is closed.
+This might for instance trying to execute a rollback for when the wrapper is used for a database connection
+
+On a regular interval (RECONNECT_INTERVAL) the wrapper will try to restore the connection.
+When the connection is restored, the failed command is re-executed
+"""
+import functools
+from time import sleep
+
+RECONNECT_INTERVAL = 60  # Duration in seconds to try to reconnect
+
+
+class AutoReconnector:
+
+    def __init__(self, is_connected, connect, disconnect):
+        """Constructor
+
+        Register the required functions to recognise and restore connection problems
+
+        :param is_connected: Function that tells whether the connection is alive and working OK
+        :param connect: Function to establish a connection
+        :param disconnect: Function to close a connection
+        """
+        self.is_connected = is_connected
+        self.connect = connect
+        self.disconnect = disconnect
+
+    def reconnect(self):
+        """Reconnect
+
+        First the connection is closed. This allows for cleanup the connection data and probably do some error recovery
+
+        Program execution is then paused for RECONNECT_INTERVAL seconds
+
+        After that, the connection is tried to re-establish
+
+        If re-establishment fails the whole reconnect procedure is retried
+
+        :return:
+        """
+        self.disconnect()
+        print(f"Try to reconnect in {RECONNECT_INTERVAL} seconds...")
+        sleep(RECONNECT_INTERVAL)
+        if not self.connect():
+            self.reconnect()  # Try again...
+
+    def exec(self, func, *args, **kwargs):
+        """Execute a method and catch any connection problems
+
+        An optimistic approach is used.
+
+        The function is executed
+        Any exceptions are catched.
+        If the exception is due to a connection problem, a reconnect is executed
+        Once the connection is re-established the whole exec procedure is retried
+
+        :param func: the function to execute
+        :param args: function parameters
+        :param kwargs: function parameters
+        :return: the function result
+        """
+        result = None
+        try:
+            # Optimistic execution
+            # Try to execute function, catch any exception
+            result = func(*args, **kwargs)
+        except Exception as e:
+            # Check if the exception is due to a connection problem
+            if not self.is_connected():
+                # Report connection problem
+                print("Connection problem, operation failed", str(e))
+                self.reconnect()
+                return self.exec(func, *args, **kwargs)  # Try again...
+            else:
+                # If not, re-raise the exception
+                raise e
+        return result
+
+
+def auto_reconnect_wrapper(is_connected, connect, disconnect):
+    """Auto reconnect wrapper
+
+    This function returns a wrapper that can be used to protect functions against connection problems.
+
+    In order to do this, the wrapper requires a couple of methods to control the connection
+
+    :param is_connected: Function that tells whether the connection is alive and working OK
+    :param connect: Function to establish a connection
+    :param disconnect: Function to close a connection
+    :return: A wrapper function
+    """
+
+    # Instantiate an auto reconnector object
+    auto_reconnector = AutoReconnector(is_connected, connect, disconnect)
+
+    # Use to auto reconnector to implement the wrapper
+    def wrapper(func):
+        @functools.wraps(func)
+        def inner_wrapper(*args, **kwargs):
+            return auto_reconnector.exec(func, *args, **kwargs)
+
+        return inner_wrapper
+
+    return wrapper

--- a/src/test.sh
+++ b/src/test.sh
@@ -11,4 +11,4 @@ pytest tests/
 
 echo "Running coverage tests"
 
-pytest tests/ --cov=gobworkflow --cov-report html --cov-fail-under=93
+pytest tests/ --cov=gobworkflow --cov-report html --cov-fail-under=100

--- a/src/tests/test_session_wrapper.py
+++ b/src/tests/test_session_wrapper.py
@@ -1,0 +1,84 @@
+from unittest import TestCase, mock
+
+from gobworkflow.storage.auto_reconnect_wrapper import AutoReconnector, auto_reconnect_wrapper
+
+def raise_exception():
+    raise Exception("Exception")
+
+def get_n_times_function(n, on_fail, on_success):
+    def n_times():
+        nonlocal n
+        if n > 0:
+            n -= 1
+            return on_fail()
+        else:
+            return on_success()
+    return n_times
+
+class TestAutoReconnect(TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_init(self):
+        obj = AutoReconnector(None, None, None)
+        self.assertIsNotNone(obj)
+
+    def test_disconnect(self):
+        mock_disconnect = mock.MagicMock()
+        obj = AutoReconnector(None, None, mock_disconnect)
+        obj.disconnect()
+        mock_disconnect.assert_called()
+
+    def test_connect(self):
+        mock_connect = mock.MagicMock()
+        obj = AutoReconnector(is_connected=None, connect=mock_connect, disconnect=None)
+        result = obj.connect()
+        mock_connect.assert_called()
+
+    def test_exec(self):
+        is_connected = lambda: True
+        mock_connect = mock.MagicMock()
+        mock_disconnect = mock.MagicMock()
+        obj = AutoReconnector(is_connected=is_connected, connect=mock_connect, disconnect=mock_disconnect)
+
+        f = lambda: "exec"
+        result = obj.exec(f)
+        self.assertEqual(result, "exec")
+        mock_connect.assert_not_called()
+        mock_disconnect.assert_not_called()
+
+    @mock.patch("gobworkflow.storage.auto_reconnect_wrapper.RECONNECT_INTERVAL", 0)
+    def test_exec_fails(self):
+        is_connected = lambda: False
+        mock_connect = get_n_times_function(2, lambda: False, lambda: True)
+        mock_disconnect = mock.MagicMock()
+        obj = AutoReconnector(is_connected=is_connected, connect=mock_connect, disconnect=mock_disconnect)
+
+        f = get_n_times_function(2, lambda: raise_exception(), lambda: "exec")
+        result = obj.exec(f)
+        self.assertEqual(result, "exec")
+        mock_disconnect.assert_called()
+
+    def test_exec_fails_otherwise(self):
+        is_connected = lambda: True
+        obj = AutoReconnector(is_connected=is_connected, connect=None, disconnect=None)
+
+        with self.assertRaises(Exception):
+            obj.exec(lambda: raise_exception())
+
+class TestAutoReconnectWrapper(TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_create(self):
+        wrapper = auto_reconnect_wrapper(None, None, None)
+        # self.assertIsInstance(wrapper, function)
+
+    def test_exec(self):
+        is_connected = lambda: True
+        wrapper = auto_reconnect_wrapper(is_connected, None, None)
+        f = lambda: "exec"
+        result = wrapper(f)()
+        self.assertEqual(result, "exec")


### PR DESCRIPTION
A decorator that automatically reconnects when execution
fails due to connection problems.

The decorator can handle any connections, as long as a
connect, disconnect and is_connected function are provided

The decorator should be moved to GOB-Core when accepted
and then also be used for the communication with the
message broker.

The current implementation is for GOB Workflow only and
serves a starting point for moving it to GOB Core

Coverage set to 100%