### PR TITLE
Allow one or more collections for relate

### DIFF
--- a/src/gobworkflow/start/__main__.py
+++ b/src/gobworkflow/start/__main__.py
@@ -99,10 +99,18 @@ The GOB workflow commands are:
         parser.add_argument('catalogue',
                             type=str,
                             help='the name of the data catalog (example: "meetbouten"')
+        parser.add_argument('collections',
+                            nargs='*',
+                            type=str,
+                            default='',
+                            help='a space separated list of collections (example: "meetbouten metingen"')
         # Skip the first argument
         args = parser.parse_args(sys.argv[2:])
-        print(f"Trigger build relations for {args.catalogue}")
-        Workflow(RELATE).start({"catalogue": args.catalogue})
+        collections = ' '.join(args.collections)
+        print(f"Trigger build relations for {args.catalogue} {collections}")
+        # Relate expects a string of collections or None
+        collections = collections if args.collections else None
+        Workflow(RELATE).start({"catalogue": args.catalogue, "collections": collections})
 
 
 def init():

--- a/src/tests/start/test_main.py
+++ b/src/tests/start/test_main.py
@@ -95,6 +95,7 @@ class TestStart(TestCase):
         mock_argparse.return_value = MockArgumentParser()
         MockArgumentParser.arguments['command'] = 'relate'
         MockArgumentParser.arguments['catalogue'] = 'catalogue'
+        MockArgumentParser.arguments['collections'] = []
 
         __main__.WorkflowCommands()
 
@@ -102,7 +103,42 @@ class TestStart(TestCase):
 
         instance = mock_workflow.return_value
         assert instance.start.call_count == 1
-        instance.start.assert_called_with({'catalogue': 'catalogue'})
+        instance.start.assert_called_with({'catalogue': 'catalogue', 'collections': None})
+
+
+    @mock.patch('gobworkflow.start.__main__.Workflow')
+    @mock.patch('argparse.ArgumentParser')
+    def test_WorkflowCommands_relate_single(self, mock_argparse, mock_workflow):
+        mock_argparse.return_value = MockArgumentParser()
+        MockArgumentParser.arguments['command'] = 'relate'
+        MockArgumentParser.arguments['catalogue'] = 'catalogue'
+        MockArgumentParser.arguments['collections'] = ['collection']
+
+        __main__.WorkflowCommands()
+
+        mock_workflow.assert_called_with(RELATE)
+
+        instance = mock_workflow.return_value
+        assert instance.start.call_count == 1
+        instance.start.assert_called_with({'catalogue': 'catalogue', 'collections': 'collection'})
+
+
+    @mock.patch('gobworkflow.start.__main__.Workflow')
+    @mock.patch('argparse.ArgumentParser')
+    def test_WorkflowCommands_relate_multiple(self, mock_argparse, mock_workflow):
+        mock_argparse.return_value = MockArgumentParser()
+        MockArgumentParser.arguments['command'] = 'relate'
+        MockArgumentParser.arguments['catalogue'] = 'catalogue'
+        MockArgumentParser.arguments['collections'] = ['collection1', 'collection2']
+
+        __main__.WorkflowCommands()
+
+        mock_workflow.assert_called_with(RELATE)
+
+        instance = mock_workflow.return_value
+        assert instance.start.call_count == 1
+        instance.start.assert_called_with({'catalogue': 'catalogue', 'collections': 'collection1 collection2'})
+
 
     @mock.patch('gobworkflow.start.__main__.Workflow')
     @mock.patch('argparse.ArgumentParser')


### PR DESCRIPTION
This commit makes it possible to relate one or more collections from a catalogue instead of triggering the full catalogue