### PR TITLE
Prevent that actions might run against an outdated database

### DIFF
--- a/src/gobworkflow/__main__.py
+++ b/src/gobworkflow/__main__.py
@@ -16,7 +16,7 @@ from gobcore.message_broker.config import JOBSTEP_RESULT_QUEUE, LOG_QUEUE, AUDIT
 from gobcore.message_broker.messagedriven_service import messagedriven_service
 from gobcore.logging.logger import logger
 
-from gobworkflow.storage.storage import connect, save_log, save_audit_log
+from gobworkflow.storage.storage import connect, wait_for_storage, save_log, save_audit_log
 from gobworkflow.workflow.jobs import step_status
 from gobworkflow.workflow.workflow import Workflow
 from gobworkflow.heartbeats import on_heartbeat
@@ -145,6 +145,7 @@ if args.migrate:
     print("End migratiion")
 else:
     connect()
+    wait_for_storage()
 
     params = {
         "prefetch_count": 1,

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -43,7 +43,8 @@ class TestMain(TestCase):
     @mock.patch('gobworkflow.workflow.jobs.step_status')
     @mock.patch('gobworkflow.workflow.workflow.Workflow')
     @mock.patch('gobworkflow.workflow.hooks.handle_result')
-    def test_main(self, mock_handle, mock_workflow, mock_status, mock_get_job_step, mock_connect, mock_messagedriven_service):
+    @mock.patch('gobworkflow.storage.storage.wait_for_storage')
+    def test_main(self, mock_wait, mock_handle, mock_workflow, mock_status, mock_get_job_step, mock_connect, mock_messagedriven_service):
 
         # With command line arguments
         sys.argv = ['python -m gobworkflow']
@@ -53,6 +54,8 @@ class TestMain(TestCase):
 
         # Should connect to the storage
         mock_connect.assert_called_with()
+        # Should check for any pending migrations
+        mock_wait.assert_called_with()
         # Should start as a service
         mock_messagedriven_service.assert_called_with(__main__.SERVICEDEFINITION,
                                                  "Workflow",


### PR DESCRIPTION
If any migrations have not been applied issue a message
to apply the migrations manually

Check every 30 seconds if the migrations have been applied
and continue if the storage is up-to-date