### PR TITLE
Synchronize migrations

### DIFF
--- a/src/gobworkflow/__main__.py
+++ b/src/gobworkflow/__main__.py
@@ -16,7 +16,7 @@ from gobcore.message_broker.config import JOBSTEP_RESULT_QUEUE, LOG_QUEUE, AUDIT
 from gobcore.message_broker.messagedriven_service import messagedriven_service
 from gobcore.logging.logger import logger
 
-from gobworkflow.storage.storage import connect, save_log, save_audit_log
+from gobworkflow.storage.storage import connect, wait_for_storage, save_log, save_audit_log
 from gobworkflow.workflow.jobs import step_status
 from gobworkflow.workflow.workflow import Workflow
 from gobworkflow.heartbeats import on_heartbeat
@@ -145,6 +145,7 @@ if args.migrate:
     print("End migratiion")
 else:
     connect()
+    wait_for_storage()
 
     params = {
         "prefetch_count": 1,

--- a/src/gobworkflow/__main__.py
+++ b/src/gobworkflow/__main__.py
@@ -16,7 +16,7 @@ from gobcore.message_broker.config import JOBSTEP_RESULT_QUEUE, LOG_QUEUE, AUDIT
 from gobcore.message_broker.messagedriven_service import messagedriven_service
 from gobcore.logging.logger import logger
 
-from gobworkflow.storage.storage import connect, wait_for_storage, save_log, save_audit_log
+from gobworkflow.storage.storage import connect, save_log, save_audit_log
 from gobworkflow.workflow.jobs import step_status
 from gobworkflow.workflow.workflow import Workflow
 from gobworkflow.heartbeats import on_heartbeat
@@ -140,12 +140,10 @@ parser.add_argument('--migrate',
 args = parser.parse_args()
 
 if args.migrate:
-    print("Start migration")
-    connect(migrate=True)
-    print("End migratiion")
+    print("Storage migration forced")
+    connect(force_migrate=True)
 else:
     connect()
-    wait_for_storage()
 
     params = {
         "prefetch_count": 1,

--- a/src/gobworkflow/storage/storage.py
+++ b/src/gobworkflow/storage/storage.py
@@ -62,7 +62,7 @@ def migrate_storage(force_migrate):
     by a lock.
 
     This method will always unlock the lock, even if a lock has not been set.
-    This allows to unlock
+    When using the force_migrate option the lock is passed and any open lock will be released
 
     The reason for setting the lock is to prevent multiple migrations that might lock each other
     :return:

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -43,7 +43,8 @@ class TestMain(TestCase):
     @mock.patch('gobworkflow.workflow.jobs.step_status')
     @mock.patch('gobworkflow.workflow.workflow.Workflow')
     @mock.patch('gobworkflow.workflow.hooks.handle_result')
-    def test_main(self, mock_handle, mock_workflow, mock_status, mock_get_job_step, mock_connect, mock_messagedriven_service):
+    @mock.patch('gobworkflow.storage.storage.wait_for_storage')
+    def test_main(self, mock_wait, mock_handle, mock_workflow, mock_status, mock_get_job_step, mock_connect, mock_messagedriven_service):
 
         # With command line arguments
         sys.argv = ['python -m gobworkflow']
@@ -53,6 +54,8 @@ class TestMain(TestCase):
 
         # Should connect to the storage
         mock_connect.assert_called_with()
+        # Should check for any pending migrations
+        mock_wait.assert_called_with()
         # Should start as a service
         mock_messagedriven_service.assert_called_with(__main__.SERVICEDEFINITION,
                                                  "Workflow",

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -34,7 +34,7 @@ class TestMain(TestCase):
         importlib.reload(__main__)
 
         # Should connect to the storage
-        mock_connect.assert_called_with(migrate=True)
+        mock_connect.assert_called_with(force_migrate=True)
 
     @mock.patch('gobcore.logging.logger.logger', mock.MagicMock())
     @mock.patch('gobcore.message_broker.messagedriven_service.messagedriven_service')
@@ -43,8 +43,7 @@ class TestMain(TestCase):
     @mock.patch('gobworkflow.workflow.jobs.step_status')
     @mock.patch('gobworkflow.workflow.workflow.Workflow')
     @mock.patch('gobworkflow.workflow.hooks.handle_result')
-    @mock.patch('gobworkflow.storage.storage.wait_for_storage')
-    def test_main(self, mock_wait, mock_handle, mock_workflow, mock_status, mock_get_job_step, mock_connect, mock_messagedriven_service):
+    def test_main(self, mock_handle, mock_workflow, mock_status, mock_get_job_step, mock_connect, mock_messagedriven_service):
 
         # With command line arguments
         sys.argv = ['python -m gobworkflow']
@@ -54,8 +53,6 @@ class TestMain(TestCase):
 
         # Should connect to the storage
         mock_connect.assert_called_with()
-        # Should check for any pending migrations
-        mock_wait.assert_called_with()
         # Should start as a service
         mock_messagedriven_service.assert_called_with(__main__.SERVICEDEFINITION,
                                                  "Workflow",

--- a/src/tests/test_storage.py
+++ b/src/tests/test_storage.py
@@ -7,7 +7,7 @@ from gobcore.model.sa.management import Job, JobStep, Task
 
 import gobworkflow.storage
 
-from gobworkflow.storage.storage import connect, wait_for_storage, disconnect, is_connected
+from gobworkflow.storage.storage import connect, migrate_storage, disconnect, is_connected
 from gobworkflow.storage.storage import save_log, get_services, remove_service, mark_service_dead, update_service, \
     _update_servicetasks, save_audit_log
 from gobworkflow.storage.storage import job_save, job_update, step_save, step_update, get_job_step, job_runs
@@ -133,38 +133,32 @@ class TestStorage(TestCase):
         update_service(service, [])
         self.assertEqual(mockedSession._first.is_alive, service["is_alive"])
 
-    @mock.patch("gobworkflow.storage.storage.alembic.config")
+    @mock.patch("gobworkflow.storage.storage.migrate_storage")
     @mock.patch("gobworkflow.storage.storage.create_engine")
-    def test_connect(self, mock_create, mock_alembic):
-        mock_alembic.main = mock.MagicMock()
-
-        result = connect(migrate=True)
+    def test_connect(self, mock_create, mock_migrate):
+        result = connect()
 
         mock_create.assert_called()
-        mock_alembic.main.assert_called()
+        mock_migrate.assert_called()
         self.assertEqual(result, True)
         self.assertEqual(is_connected(), True)
 
     @mock.patch("gobworkflow.storage.storage.DBAPIError", MockException)
     @mock.patch("gobworkflow.storage.storage.create_engine", mock.MagicMock())
-    @mock.patch("gobworkflow.storage.storage.alembic.config")
-    def test_connect_error(self, mock_alembic):
+    @mock.patch("gobworkflow.storage.storage.migrate_storage", lambda argv: raise_exception(MockException))
+    def test_connect_error(self):
         # Operation errors should be catched
-        mock_alembic.main = lambda argv: raise_exception(MockException)
-
-        result = connect(migrate=True)
+        result = connect()
 
         self.assertEqual(result, False)
         self.assertEqual(is_connected(), False)
 
-    @mock.patch("gobworkflow.storage.storage.alembic.config")
+    @mock.patch("gobworkflow.storage.storage.migrate_storage", lambda force_migrate: raise_exception(MockException))
     @mock.patch("gobworkflow.storage.storage.create_engine", mock.MagicMock())
-    def test_connect_other_error(self, mock_alembic):
+    def test_connect_other_error(self):
         # Only operational errors should be catched
-        mock_alembic.main = lambda argv: raise_exception(MockException)
-
         with self.assertRaises(MockException):
-            connect(migrate=True)
+            connect()
 
     @mock.patch("gobworkflow.storage.storage.engine.dispose")
     @mock.patch("gobworkflow.storage.storage.session.close")
@@ -392,22 +386,58 @@ class TestStorage(TestCase):
         self.assertEqual({"stepid": "someid"}, mock_session.filter_kwargs)
         self.assertEqual(['a', 'b'], result)
 
+    @mock.patch("gobworkflow.storage.storage.alembic.config")
     @mock.patch('gobworkflow.storage.storage.alembic.script')
     @mock.patch('gobworkflow.storage.storage.migration')
-    @mock.patch('gobworkflow.storage.storage.time')
-    def test_wait_for_storage(self, mock_time, mock_migration, mock_script):
+    def test_migrate_storage(self, mock_migration, mock_script, mock_config):
         context = mock.MagicMock()
-        context.get_current_revision.side_effect = ["revision 1", "revision 2"]
+        context.get_current_revision.return_value = "revision 1"
         mock_migration.MigrationContext.configure.return_value = context
 
         script = mock.MagicMock()
         script.get_current_head.return_value = "revision 2"
         mock_script.ScriptDirectory.from_config.return_value = script
 
-        wait_for_storage()
-        self.assertEqual(script.get_current_head.call_count, 2)
-        self.assertEqual(context.get_current_revision.call_count, 2)
-        self.assertEqual(mock_time.sleep.call_count, 1)
+        migrate_storage(force_migrate=True)
+        self.assertEqual(script.get_current_head.call_count, 1)
+        self.assertEqual(context.get_current_revision.call_count, 1)
+        mock_config.main.assert_called()
+
+    @mock.patch("gobworkflow.storage.storage.alembic.config")
+    @mock.patch('gobworkflow.storage.storage.alembic.script')
+    @mock.patch('gobworkflow.storage.storage.migration')
+    def test_migrate_storage_up_to_date(self, mock_migration, mock_script, mock_config):
+        context = mock.MagicMock()
+        context.get_current_revision.return_value = "revision 2"
+        mock_migration.MigrationContext.configure.return_value = context
+
+        script = mock.MagicMock()
+        script.get_current_head.return_value = "revision 2"
+        mock_script.ScriptDirectory.from_config.return_value = script
+
+        migrate_storage(force_migrate=False)
+        self.assertEqual(script.get_current_head.call_count, 1)
+        self.assertEqual(context.get_current_revision.call_count, 1)
+        mock_config.main.assert_not_called()
+
+    @mock.patch("gobworkflow.storage.storage.alembic.config")
+    @mock.patch('gobworkflow.storage.storage.alembic.script')
+    @mock.patch('gobworkflow.storage.storage.migration')
+    def test_migrate_storage_exception(self, mock_migration, mock_script, mock_config):
+        context = mock.MagicMock()
+        context.get_current_revision.return_value = "revision 1"
+        mock_migration.MigrationContext.configure.return_value = context
+
+        script = mock.MagicMock()
+        script.get_current_head.return_value = "revision 2"
+        mock_script.ScriptDirectory.from_config.return_value = script
+
+        mock_config.main = lambda argv: raise_exception(MockException)
+
+        migrate_storage(force_migrate=False)
+        self.assertEqual(script.get_current_head.call_count, 1)
+        self.assertEqual(context.get_current_revision.call_count, 1)
+
 
 class TestJobRuns(TestCase):
 


### PR DESCRIPTION
This is an alternative solution proposal.

Instead of waiting for manual migration synchronize automatic migration.
Prevent to connect to the message broker on the basis of an outdated db.
