### PR TITLE
Don’t allow the same action on a catalog/collection

### DIFF
--- a/src/gobworkflow/workflow/jobs.py
+++ b/src/gobworkflow/workflow/jobs.py
@@ -27,7 +27,7 @@ def job_start(job_name, msg):
     """
     timestamp = _timestamp()
     # Concatenate all the non-header fields
-    args = [str(val) for key, val in sorted(msg.get('header', {}).items())]
+    args = [str(val) for key, val in msg.get('header', {}).items()]
     job_info = {
         "name": f"{job_name}.{'.'.join(args)}",
         "type": job_name,

--- a/src/gobworkflow/workflow/workflow.py
+++ b/src/gobworkflow/workflow/workflow.py
@@ -60,7 +60,7 @@ class Workflow():
                 **msg.get('header', {}),
                 'process_id': job['id']
             }
-            if job_runs(job):
+            if job_runs(job, msg):
                 return self.reject(self._workflow_name, msg, job)
         self._function(self._step_name)(msg)
         return job

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -9,7 +9,7 @@ flake8==3.5.0
 freezegun==0.3.12
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.13.34#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.13.36#egg=gobcore
 idna==2.7
 Mako==1.0.7
 MarkupSafe==1.1.0

--- a/src/tests/workflow/test_workflow.py
+++ b/src/tests/workflow/test_workflow.py
@@ -48,7 +48,7 @@ class TestWorkflow(TestCase):
     def test_create(self):
         self.assertIsNotNone(self.workflow)
 
-    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j: False)
+    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k: False)
     @mock.patch("gobworkflow.workflow.workflow.step_start")
     @mock.patch("gobworkflow.workflow.workflow.job_start")
     def test_start(self, job_start, step_start):
@@ -75,7 +75,7 @@ class TestWorkflow(TestCase):
         })
 
     @mock.patch("gobworkflow.workflow.workflow.logger", mock.MagicMock())
-    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j: True)
+    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k: True)
     @mock.patch("gobworkflow.workflow.workflow.step_start")
     @mock.patch("gobworkflow.workflow.workflow.job_start")
     def test_start_and_end_job_runs(self, job_start, step_start):
@@ -84,7 +84,7 @@ class TestWorkflow(TestCase):
         job_start.assert_called_with("Workflow", {'header': {'process_id': mock.ANY, 'entity': None}})
         step_start.assert_called_with('accept', {'process_id': mock.ANY, 'entity': None})
 
-    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j: False)
+    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k: False)
     @mock.patch("gobworkflow.workflow.workflow.logger", mock.MagicMock())
     @mock.patch("gobworkflow.workflow.workflow.step_start")
     @mock.patch("gobworkflow.workflow.workflow.job_start")
@@ -95,7 +95,7 @@ class TestWorkflow(TestCase):
         job_start.assert_called_with('Workflow', {'header': {'process_id': 'Any process id'}, 'summary': {}})
         step_start.assert_called_with('Step', {'process_id': 'Any process id'})
 
-    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j: False)
+    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k: False)
     @mock.patch("gobworkflow.workflow.workflow.step_start")
     @mock.patch("gobworkflow.workflow.workflow.job_start")
     def test_start_with_contents(self, job_start, step_start):


### PR DESCRIPTION
Workflow now checks for catalog collection in the arguments to prevent full and partial import to run at the same time.