### PR TITLE
Update task queues. Rename id to task_name and put task_name in header instead of body

### DIFF
--- a/src/gobworkflow/task/queue.py
+++ b/src/gobworkflow/task/queue.py
@@ -70,7 +70,7 @@ class TaskQueue:
         :param tasks:
         :return:
         """
-        ids = [task['id'] for task in tasks if 'id' in task]
+        ids = [task['task_name'] for task in tasks if 'task_name' in task]
         assert len(set(ids)) == len(tasks), "All tasks should have a unique id"
 
         done = []
@@ -80,9 +80,10 @@ class TaskQueue:
 
             for dependency in task['dependencies']:
                 if dependency not in done:
-                    raise GOBException(f"Task {task['id']} depends on task {dependency}, but isn't executed yet")
+                    raise GOBException(f"Task {task['task_name']} depends on task {dependency}, "
+                                       f"but isn't executed yet")
 
-            done.append(task['id'])
+            done.append(task['task_name'])
 
     def _create_tasks(self, jobid, stepid, process_id, tasks, key_prefix, extra_msg, extra_header):
         """Create Task objects for the input list 'tasks'.
@@ -99,7 +100,7 @@ class TaskQueue:
 
         for task in tasks:
             task_def = {
-                'name': task['id'],
+                'name': task['task_name'],
                 'dependencies': task['dependencies'],
                 'status': self.STATUS_NEW,
                 'jobid': jobid,
@@ -143,11 +144,11 @@ class TaskQueue:
         msg = {
             **task.extra_msg,
             'taskid': task.id,
-            'id': task.name,
             'header': {
                 'jobid': task.jobid,
                 'stepid': task.stepid,
                 'process_id': task.process_id,
+                'task_name': task.name,
                 **task.extra_header,
             }
         }

--- a/src/gobworkflow/task/queue.py
+++ b/src/gobworkflow/task/queue.py
@@ -70,8 +70,8 @@ class TaskQueue:
         :param tasks:
         :return:
         """
-        ids = [task['task_name'] for task in tasks if 'task_name' in task]
-        assert len(set(ids)) == len(tasks), "All tasks should have a unique id"
+        task_names = [task['task_name'] for task in tasks if 'task_name' in task]
+        assert len(set(task_names)) == len(tasks), "All tasks should have a unique name"
 
         done = []
 

--- a/src/tests/task/test_queue.py
+++ b/src/tests/task/test_queue.py
@@ -17,9 +17,9 @@ class TestTaskQueue(TestCase):
 
     def setUp(self) -> None:
         self.tasks = [
-            {'id': 'task id 1', 'dependencies': []},
-            {'id': 'task id 2', 'dependencies': ['task id 1']},
-            {'id': 'task id 3', 'dependencies': ['task id 1', 'task id 2']},
+            {'task_name': 'task id 1', 'dependencies': []},
+            {'task_name': 'task id 2', 'dependencies': ['task id 1']},
+            {'task_name': 'task id 3', 'dependencies': ['task id 1', 'task id 2']},
         ]
         self.start_message = {
             'header': {
@@ -85,12 +85,12 @@ class TestTaskQueue(TestCase):
         self.task_queue._validate_dependencies(self.tasks)
 
     def test_validate_dependencies_double_id(self):
-        self.tasks[2]['id'] = self.tasks[1]['id']
+        self.tasks[2]['task_name'] = self.tasks[1]['task_name']
         with self.assertRaises(AssertionError):
             self.task_queue._validate_dependencies(self.tasks)
 
     def test_validate_dependencies_circular_dependency(self):
-        self.tasks[0]['dependencies'] = [self.tasks[1]['id']]
+        self.tasks[0]['dependencies'] = [self.tasks[1]['task_name']]
 
         with self.assertRaises(GOBException):
             self.task_queue._validate_dependencies(self.tasks)
@@ -110,7 +110,7 @@ class TestTaskQueue(TestCase):
 
         mock_task_save.assert_has_calls([
             call({
-                'name': self.tasks[0]['id'],
+                'name': self.tasks[0]['task_name'],
                 'dependencies': self.tasks[0]['dependencies'],
                 'status': self.task_queue.STATUS_NEW,
                 'jobid': self.jobid,
@@ -124,7 +124,7 @@ class TestTaskQueue(TestCase):
                 'process_id': self.process_id,
             }),
             call({
-                'name': self.tasks[1]['id'],
+                'name': self.tasks[1]['task_name'],
                 'dependencies': self.tasks[1]['dependencies'],
                 'status': self.task_queue.STATUS_NEW,
                 'jobid': self.jobid,
@@ -192,10 +192,10 @@ class TestTaskQueue(TestCase):
         mock_publish.assert_called_with(WORKFLOW_EXCHANGE, task.key_prefix + ".task.request", {
             'extra': 'msg',
             'taskid': task.id,
-            'id': task.name,
             'header': {
                 'jobid': task.jobid,
                 'stepid': task.stepid,
+                'task_name': task.name,
                 'process_id': task.process_id,
                 'extra': 'header',
             }


### PR DESCRIPTION
- task_name in header so that this can be used when running standalone
- id to task_name is for readability - now we're at it

Should be deployed together with https://github.com/Amsterdam/GOB-Prepare/pull/389