### PR TITLE
Prevent multiple EVENT_PRODUCE jobs to run in parallel, without exceptions for zombies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ./src/gobworkflow:/app/gobworkflow
       - ./src/tests:/app/tests
       - ./src/alembic:/app/alembic
-#      - ${GOB_CORE_DIR-../GOB-Core}:/app/GOB-Core
+      - ${GOB_CORE_DIR-../GOB-Core}:/app/GOB-Core
 
 volumes:
   gob-volume:

--- a/src/gobworkflow/storage/storage.py
+++ b/src/gobworkflow/storage/storage.py
@@ -344,7 +344,7 @@ def job_get(job_id):
 
 
 @session_auto_reconnect
-def job_runs(jobinfo: Job, msg: dict) -> bool:
+def job_runs(jobinfo: Job, msg: dict, allow_parallel_zombie: bool = True) -> bool:
     """
     Checks for job duplicate based on header information, if all equal:
      - Model:
@@ -382,7 +382,13 @@ def job_runs(jobinfo: Job, msg: dict) -> bool:
     if job is None:
         return False
 
-    print(f"Found already running job '{job.id}', started {job.start} (zombie: {job.is_zombie()})")
+    print(
+        f"Found already running job '{job.id}', started {job.start} (zombie: {job.is_zombie()}, "
+        f"allow_parallel_zombie: {allow_parallel_zombie})"
+    )
+
+    if not allow_parallel_zombie:
+        return True
     return not job.is_zombie()
 
 

--- a/src/tests/test_storage.py
+++ b/src/tests/test_storage.py
@@ -517,6 +517,10 @@ class TestJobRuns(TestCase):
         result = job_runs(job_info, msg)
         self.assertEqual(result, False)
 
+        # Is zombie, but should not be allowed to run a job in parallel
+        result = job_runs(job_info, msg, allow_parallel_zombie=False)
+        self.assertEqual(result, True)
+
     @mock.patch('gobworkflow.storage.storage.ARRAY')
     @mock.patch('gobworkflow.storage.storage.cast')
     @mock.patch('gobworkflow.storage.storage.Job')

--- a/src/tests/workflow/test_workflow.py
+++ b/src/tests/workflow/test_workflow.py
@@ -214,7 +214,7 @@ class TestWorkflow(TestCase):
             wf = Workflow('Workflow', dynamic_workflow_steps=dynamic)
 
     @mock.patch("gobworkflow.workflow.workflow.WORKFLOWS", WORKFLOWS)
-    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k: False)
+    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k, **kwargs: False)
     @mock.patch("gobworkflow.workflow.workflow.step_start")
     @mock.patch("gobworkflow.workflow.workflow.job_start")
     def test_start(self, job_start, step_start, mock_tree):
@@ -244,7 +244,7 @@ class TestWorkflow(TestCase):
 
     @mock.patch("gobworkflow.workflow.workflow.WORKFLOWS", WORKFLOWS)
     @mock.patch("gobworkflow.workflow.workflow.logger", mock.MagicMock())
-    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k: True)
+    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k, **kwargs: True)
     @mock.patch("gobworkflow.workflow.workflow.step_start")
     @mock.patch("gobworkflow.workflow.workflow.job_start")
     def test_start_and_end_job_runs(self, job_start, step_start, mock_tree):
@@ -256,7 +256,7 @@ class TestWorkflow(TestCase):
         job_start.assert_called_with("Workflow", {'header': {'process_id': mock.ANY}})
 
     @mock.patch("gobworkflow.workflow.workflow.WORKFLOWS", WORKFLOWS)
-    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k: False)
+    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k, **kwargs: False)
     @mock.patch("gobworkflow.workflow.workflow.logger", mock.MagicMock())
     @mock.patch("gobworkflow.workflow.workflow.step_start")
     @mock.patch("gobworkflow.workflow.workflow.job_start")
@@ -268,7 +268,7 @@ class TestWorkflow(TestCase):
         step_start.assert_called_with('Step', {})
 
     @mock.patch("gobworkflow.workflow.workflow.WORKFLOWS", WORKFLOWS)
-    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k: False)
+    @mock.patch("gobworkflow.workflow.workflow.job_runs", lambda j, k, **kwargs: False)
     @mock.patch("gobworkflow.workflow.workflow.step_start")
     @mock.patch("gobworkflow.workflow.workflow.job_start")
     def test_start_with_contents(self, job_start, step_start, mock_tree):


### PR DESCRIPTION
Because some jobs may run longer than 12 hours, and we don't want to have two event producing processes to interfere with each other.