### PR TITLE
fix voor missende summary object in de taks

### DIFF
--- a/src/gobworkflow/task/queue.py
+++ b/src/gobworkflow/task/queue.py
@@ -233,9 +233,14 @@ class TaskQueue:
         :return:
         """
         all_tasks = get_tasks_for_stepid(task.stepid)
-        warnings = [warning for sublist in [t.summary["warnings"] for t in all_tasks] for warning in sublist]
-        errors = [error for sublist in [t.summary["errors"] for t in all_tasks] for error in sublist]
-
+        warnings = [
+            warning
+            for sublist in [t.summary["warnings"] for t in all_tasks if t.summary is not None]
+            for warning in sublist
+        ]
+        errors = [
+            error for sublist in [t.summary["errors"] for t in all_tasks if t.summary is not None] for error in sublist
+        ]
         msg = {
             **task.extra_msg,
             "header": {

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
 alembic==1.11.3
 freezegun==1.2.2
--e git+https://github.com/Amsterdam/GOB-Core.git@v2.18.0#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v2.20.1#egg=gobcore

--- a/src/tests/task/test_queue.py
+++ b/src/tests/task/test_queue.py
@@ -339,6 +339,7 @@ class TestTaskQueue(TestCase):
         mock_get_tasks.return_value = [
             Task(id=1, name='task1', status=self.task_queue.STATUS_COMPLETED, summary=summary1),
             Task(id=2, name='task2', status=self.task_queue.STATUS_NEW, summary=summary2),
+            Task(id=3, name='task3', status=self.task_queue.STATUS_ABORTED),
         ]
 
         task_arg = Task(stepid=self.stepid, jobid=self.jobid, key_prefix="prefix",


### PR DESCRIPTION
In het geval dat een task faalt in GOB-prepare dan wordt een bericht teruggestuurd met een error melding. Dit berich wordt verder in GOB-wrokflow in de tasks tabel verwerkt met de status "failed" en een gevulde summary met error/warning message.
De de daaropvolgende tasks in GOB-Prepare, die afhankelijk van deze task zijn, worden niet verder uitgevoerd en in GOB-workflow worden deze tasks aborted.
Bij het verwerken in de GOB-workflow van deze tasks wordt gekeken naar errors en warings in summary object. Het ontbreken van summary in deze berichten zorgt voor dat de GOB-workflow crashed met een error.
```
File "/app/gobworkflow/task/queue.py", line 238, in <listcomp>
for sublist in [t.summary["warnings"] for t in all_tasks]
TypeError: 'NoneType' object is not subscriptable
```