### PR TITLE
slim-bullseye with current Python 3.9.x and GOB-Core.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM amsterdam/gob_wheelhouse:3.9-bullseye as wheelhouse
+FROM amsterdam/gob_wheelhouse:3.9-slim-bullseye as wheelhouse
 MAINTAINER datapunt@amsterdam.nl
 
 
 # Application stage.
-FROM amsterdam/gob_baseimage:3.9-bullseye as application
+FROM amsterdam/gob_baseimage:3.9-slim-bullseye as application
 MAINTAINER datapunt@amsterdam.nl
 # GOB base image: SQL Server driver.
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
 alembic==1.11.3
 freezegun==1.2.2
-git+https://github.com/Amsterdam/GOB-Core.git@v2.22.0
+git+https://github.com/Amsterdam/GOB-Core.git@v2.23.0


### PR DESCRIPTION
slim-bullseye met Python 3.9.18 en vanwege `gobcore.model.amschema.repo.AMSchemaError: Table maatschappelijkeactiviteiten/2.7.0 does not exist in dataset hr`